### PR TITLE
Provide package overlay as Nix flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,76 +5,93 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
-        pkgs = nixpkgs.legacyPackages.${system};
-      });
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default = pkgs.rustPlatform.buildRustPackage {
-          pname = "resharp";
-          version = "0.1.0";
-          src = pkgs.lib.cleanSource ./.;
-          cargoLock.lockFile = ./Cargo.lock;
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "resharp";
+            version = "0.1.0";
+            src = pkgs.lib.cleanSource ./.;
+            cargoLock.lockFile = ./Cargo.lock;
 
-          nativeBuildInputs = [ pkgs.installShellFiles ];
+            nativeBuildInputs = [ pkgs.installShellFiles ];
 
-          postInstall = ''
-            ln -s $out/bin/resharp "$out/bin/re#"
-            installShellCompletion --cmd resharp \
-              --bash <($out/bin/resharp --completions bash) \
-              --zsh <($out/bin/resharp --completions zsh) \
-              --fish <($out/bin/resharp --completions fish)
-          '';
+            postInstall = ''
+              ln -s $out/bin/resharp "$out/bin/re#"
+              installShellCompletion --cmd resharp \
+                --bash <($out/bin/resharp --completions bash) \
+                --zsh <($out/bin/resharp --completions zsh) \
+                --fish <($out/bin/resharp --completions fish)
+            '';
 
-          meta = {
-            description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-            license = pkgs.lib.licenses.mit;
-            mainProgram = "resharp";
+            meta = {
+              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "resharp";
+            };
           };
-        };
 
-        aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform.rustPlatform.buildRustPackage {
-          pname = "resharp";
-          version = "0.1.0";
-          src = pkgs.lib.cleanSource ./.;
-          cargoLock.lockFile = ./Cargo.lock;
+          aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform.rustPlatform.buildRustPackage {
+            pname = "resharp";
+            version = "0.1.0";
+            src = pkgs.lib.cleanSource ./.;
+            cargoLock.lockFile = ./Cargo.lock;
 
-          meta = {
-            description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-            license = pkgs.lib.licenses.mit;
-            mainProgram = "resharp";
+            meta = {
+              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "resharp";
+            };
           };
-        };
 
-        windows = pkgs.pkgsCross.mingwW64.rustPlatform.buildRustPackage {
-          pname = "resharp";
-          version = "0.1.0";
-          src = pkgs.lib.cleanSource ./.;
-          cargoLock.lockFile = ./Cargo.lock;
+          windows = pkgs.pkgsCross.mingwW64.rustPlatform.buildRustPackage {
+            pname = "resharp";
+            version = "0.1.0";
+            src = pkgs.lib.cleanSource ./.;
+            cargoLock.lockFile = ./Cargo.lock;
 
-          meta = {
-            description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-            license = pkgs.lib.licenses.mit;
-            mainProgram = "resharp";
+            meta = {
+              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "resharp";
+            };
           };
-        };
-      });
+        }
+      );
 
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            cargo
-            rustc
-            clippy
-            rustfmt
-            ripgrep
-            hyperfine
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cargo
+              rustc
+              clippy
+              rustfmt
+              ripgrep
+              hyperfine
+            ];
+          };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
   outputs =
     { self, nixpkgs }:
     let
+      overlay = final: prev: {
+        resharp = final.callPackage ./resharp.nix { };
+      };
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -19,62 +22,21 @@
         nixpkgs.lib.genAttrs systems (
           system:
           f {
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            };
           }
         );
     in
     {
+      overlays.default = overlay;
       packages = forAllSystems (
         { pkgs }:
         {
-          default = pkgs.rustPlatform.buildRustPackage {
-            pname = "resharp";
-            version = "0.1.0";
-            src = pkgs.lib.cleanSource ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-
-            nativeBuildInputs = [ pkgs.installShellFiles ];
-
-            postInstall = ''
-              ln -s $out/bin/resharp "$out/bin/re#"
-              installShellCompletion --cmd resharp \
-                --bash <($out/bin/resharp --completions bash) \
-                --zsh <($out/bin/resharp --completions zsh) \
-                --fish <($out/bin/resharp --completions fish)
-            '';
-
-            meta = {
-              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "resharp";
-            };
-          };
-
-          aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform.rustPlatform.buildRustPackage {
-            pname = "resharp";
-            version = "0.1.0";
-            src = pkgs.lib.cleanSource ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-
-            meta = {
-              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "resharp";
-            };
-          };
-
-          windows = pkgs.pkgsCross.mingwW64.rustPlatform.buildRustPackage {
-            pname = "resharp";
-            version = "0.1.0";
-            src = pkgs.lib.cleanSource ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-
-            meta = {
-              description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "resharp";
-            };
-          };
+          default = pkgs.resharp;
+          aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform.callPackage ./resharp.nix { };
+          windows = pkgs.pkgsCross.mingwW64.callPackage ./resharp.nix { };
         }
       );
 

--- a/resharp.nix
+++ b/resharp.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  installShellFiles,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage {
+  pname = "resharp";
+  version = "0.1.0";
+  src = lib.cleanSource ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    ln -s $out/bin/resharp "$out/bin/re#"
+    installShellCompletion --cmd resharp \
+      --bash <($out/bin/resharp --completions bash) \
+      --zsh <($out/bin/resharp --completions zsh) \
+      --fish <($out/bin/resharp --completions fish)
+  '';
+
+  meta = {
+    description = "grep tool powered by the resharp regex engine with intersection, complement, and lookarounds";
+    license = lib.licenses.mit;
+    mainProgram = "resharp";
+  };
+}


### PR DESCRIPTION
This change adds an overlay to the flake outputs (`outputs.overlays.default`) that contains a platform-independent `resharp`. It also changes `forAllSystems` to apply the overlay to whatever `nixpkgs` is supplied in the flake inputs --- the package outputs can now simply refer to `resharp` built with the system-appropriate `rustPlatform`.

I moved the package definition into a separate `resharp.nix`. This is instantiated with `callPackage` of each package set instead of being copied multiple times. I can move the package definition back into `flake.nix` if you prefer not having extra `*.nix` files in the project root.